### PR TITLE
Ensure we check that the nullable property is an array.

### DIFF
--- a/src/NullableFields.php
+++ b/src/NullableFields.php
@@ -54,7 +54,7 @@ trait NullableFields
      */
     protected function nullableFromArray(array $attributes = [ ])
     {
-        if (count($this->nullable) > 0) {
+        if (is_array($this->nullable) && count($this->nullable) > 0) {
             return array_intersect_key($attributes, array_flip($this->nullable));
         }
 


### PR DESCRIPTION
Addresses #1.

Due to Eloquent's dynamic retrieval of attributes, $this->nullable
will always return something - even if not set. This means no notice
will be generated, but count(null) - which getAttribute returns - will
return null.

If the user defines $nullable as a string (protected $nullable = 'field')
a PHP warning will be generated when array_flip is called within the
nullableFromArray method.

Therefore, we check that $nullable is an array AND that it has a count
greater than 0 i.e. contains some values.
