### PR TITLE
Declare abstract isJsonCastable on trait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ matrix:
       env: ILLUMINATE_VERSION=5.2.*
 
 before_install:
-  - composer require "illuminate/database:${ILLUMINATE_VERSION}" --no-update
-  - composer require "illuminate/events:${ILLUMINATE_VERSION}" --no-update
+  - composer require "illuminate/database:${ILLUMINATE_VERSION}" --no-update -v
+  - composer require "illuminate/events:${ILLUMINATE_VERSION}" --no-update -v
 
-install: composer update --prefer-source --no-interaction --dev
+install: composer update --prefer-source --no-interaction --dev -v
 
 script: vendor/bin/phpunit --debug -c phpunit.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Nullable database fields for the Laravel PHP Framework
-## v1.0.0
+## v1.0.1
 
 ![Travis Build Status](https://travis-ci.org/deringer/laravel-nullable-fields.svg?branch=master)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Nullable database fields for the Laravel PHP Framework
-## v1.0.1
+## v1.0.2
 
 ![Travis Build Status](https://travis-ci.org/deringer/laravel-nullable-fields.svg?branch=master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/deringer/laravel-nullable-fields/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/deringer/laravel-nullable-fields/?branch=master)
 
 Often times, database fields that are not assigned values are defaulted to `null`. This is particularly important when creating records with foreign key constraints, where the relationship is not yet established.
 

--- a/src/NullableFields.php
+++ b/src/NullableFields.php
@@ -58,6 +58,15 @@ trait NullableFields
 
 
     /**
+     * Determine whether a value is JSON castable for inbound manipulation.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    abstract protected function isJsonCastable($key);
+
+
+    /**
      * Get the nullable attributes of a given array.
      *
      * @param  array $attributes

--- a/tests/NullableFieldsIntegrationTest.php
+++ b/tests/NullableFieldsIntegrationTest.php
@@ -9,19 +9,12 @@ use Illuminate\Events\Dispatcher;
 class NullableFieldsIntegrationTest extends PHPUnit_Framework_TestCase
 {
 
-    protected static $dbname;
-
-
     public static function setUpBeforeClass()
     {
-        static::$dbname = dirname(__FILE__) . '/database.sqlite';
-
-        touch(static::$dbname);
-
         $manager = new Manager();
         $manager->addConnection([
             'driver'   => 'sqlite',
-            'database' => static::$dbname,
+            'database' => ':memory:',
         ]);
 
         $manager->setEventDispatcher(new Dispatcher(new Container()));
@@ -38,16 +31,16 @@ class NullableFieldsIntegrationTest extends PHPUnit_Framework_TestCase
             $table->text('array_not_casted')->nullable()->default(null);
         });
     }
-    
-    
+
+
     /** @test */
     public function it_sets_nullable_fields_to_null_when_saving()
     {
-        $user = new UserProfile;
+        $user                   = new UserProfile;
         $user->facebook_profile = ' ';
         $user->twitter_profile  = 'michaeldyrynda';
         $user->linkedin_profile = '';
-        $user->array_casted = [ ];
+        $user->array_casted     = [ ];
         $user->array_not_casted = [ ];
         $user->save();
 
@@ -77,18 +70,14 @@ class NullableFieldsIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertNull($user->array_casted);
         $this->assertNull($user->array_not_casted);
     }
-
-
-    public static function tearDownAfterClass()
-    {
-        unlink(static::$dbname);
-    }
 }
-
 
 class UserProfile extends Model
 {
+
     use NullableFields;
+
+    public $timestamps = false;
 
     protected $fillable = [
         'facebook_profile',
@@ -107,7 +96,5 @@ class UserProfile extends Model
     ];
 
     protected $casts = [ 'array_casted' => 'array', ];
-
-    public $timestamps = false;
 
 }

--- a/tests/NullableFieldsTest.php
+++ b/tests/NullableFieldsTest.php
@@ -10,7 +10,7 @@ class NullableFieldsTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->nullable = $this->getObjectForTrait('Iatstuti\Database\Support\NullableFields');
+        $this->nullable = $this->getMockForTrait('Iatstuti\Database\Support\NullableFields');
     }
 
 


### PR DESCRIPTION
In order to make sure that the `isJsonCastable` method is present,
declare an abstract method for it.

This is not done for `fromJson`, as this allows us compatibility with
`illuminate/database=5.0`, which doesn’t implement this functionality.
