### PR TITLE
Fix JSON castable attributes not being cast

### DIFF
--- a/src/NullableFields.php
+++ b/src/NullableFields.php
@@ -104,6 +104,6 @@ trait NullableFields
      */
     private function getJsonCastValue($value)
     {
-        return method_exists($this, 'fromJson') ? $this->fromJson($value) : json_decode($value);
+        return method_exists($this, 'asJson') ? $this->asJson($value) : json_encode($value);
     }
 }


### PR DESCRIPTION
Instead of encoding the array to JSON, the trait is trying to decode the array from JSON - which fails because it is already an array.
