### PR TITLE
Change abstracted getAttributes() signature to compliment change in Laravel 5.3.16

### DIFF
--- a/src/NullableFields.php
+++ b/src/NullableFields.php
@@ -17,9 +17,11 @@ trait NullableFields
     /**
      * Get all of the current attributes on the model.
      *
+     * @param array $keys
+     *
      * @return array
      */
-    abstract public function getAttributes();
+    abstract public function getAttributes($keys = []);
 
 
     /**


### PR DESCRIPTION
Latest Laravel update breaks this package.

The associated change to laravel/framework is here:
https://github.com/laravel/framework/commit/52e56cda42704e65997950d1d6f3ad88d46dd5c3

This change to larvel-nullable-fields will break backwards compatibility with 5.3.15 and earlier, thus an appropriate version bump is advised.
