### PR TITLE
Fix: prevent replacing false by null

### DIFF
--- a/src/NullableFields.php
+++ b/src/NullableFields.php
@@ -105,7 +105,7 @@ trait NullableFields
             return $this->nullIfEmptyArray($key, $value);
         }
 
-        return trim($value) === '' ? null : $value;
+        return $value !== false && trim($value) === '' ? null : $value;
     }
 
 

--- a/tests/NullableFieldsIntegrationTest.php
+++ b/tests/NullableFieldsIntegrationTest.php
@@ -30,6 +30,7 @@ class NullableFieldsIntegrationTest extends PHPUnit_Framework_TestCase
             $table->string('linkedin_profile')->nullable()->default(null);
             $table->text('array_casted')->nullable()->default(null);
             $table->text('array_not_casted')->nullable()->default(null);
+            $table->boolean('boolean')->nullable()->default(null);
         });
 
         $manager->schema()->create('products', function ($table) {
@@ -152,6 +153,18 @@ class NullableFieldsIntegrationTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_doesnt_munge_a_boolean_false_value()
+    {
+        $user = UserProfile::create([
+            'facebook_profile' => '',
+            'boolean' => false,
+        ]);
+
+        $this->assertNull($user->facebook_profile);
+        $this->assertSame(false, $user->boolean);
+    }
+
+    /** @test */
     public function it_correctly_handles_empty_date_fields()
     {
         $date = DateTest::create(['last_tested_at' => '']);
@@ -181,6 +194,7 @@ class UserProfile extends Model
         'array_casted',
         'array_not_casted',
         'twitter_profile_mutated',
+        'boolean',
     ];
 
     protected $nullable = [
@@ -190,9 +204,10 @@ class UserProfile extends Model
         'array_casted',
         'array_not_casted',
         'twitter_profile_mutated',
+        'boolean',
     ];
 
-    protected $casts = ['array_casted' => 'array'];
+    protected $casts = ['array_casted' => 'array', 'boolean' => 'boolean'];
 
     public function setTwitterProfileMutatedAttribute($twitter_profile_mutated)
     {

--- a/tests/NullableFieldsTest.php
+++ b/tests/NullableFieldsTest.php
@@ -43,6 +43,13 @@ class NullableFieldsTest extends PHPUnit_Framework_TestCase
 
 
     /** @test */
+    public function it_does_not_modify_a_false_value()
+    {
+        $this->assertSame(false, $this->nullable->nullIfEmpty(false));
+    }
+
+
+    /** @test */
     public function it_correctly_handles_an_empty_array_as_null()
     {
         $this->assertNull($this->nullable->nullIfEmpty([ ]));


### PR DESCRIPTION
Hi,

If I try to store a false value in a boolean column, a null value is saved instead. This prevents me to make something like a three states column : True, False, or Undeterminated (NULL).

This pull request fix this issue by adding a test to check if the value is strictly equal to false.