### PR TITLE
Fix PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated Warning / Error in PHP 8.1

### DIFF
--- a/src/NullableFields.php
+++ b/src/NullableFields.php
@@ -67,7 +67,7 @@ trait NullableFields
             return $value;
         }
 
-        return trim($value) === '' ? null : $value;
+        return trim((string) $value) === '' ? null : $value;
     }
 
 

--- a/src/NullableFields.php
+++ b/src/NullableFields.php
@@ -67,7 +67,7 @@ trait NullableFields
             return $value;
         }
 
-        return trim((string) $value) === '' ? null : $value;
+        return blank($value) ? null : $value;
     }
 
 
@@ -166,14 +166,14 @@ trait NullableFields
     private function fetchValueForKey($key, $value)
     {
         if (in_array($key, $this->getDates())) {
-            return trim((string) $value) === '' ? null : $value;
+            return blank($value) ? null : $value;
         }
 
         if (! $this->hasSetMutator($key)) {
             $value = $this->getAttribute($key);
         }
 
-        if ($this->isJsonCastable($key) && ! is_null($value)) {
+        if ($this->isJsonCastable($key) && ! blank($value)) {
             $value = is_string($value) ? $this->getJsonCastValue($value) : $value;
         }
 
@@ -191,10 +191,10 @@ trait NullableFields
      */
     private function nullIfEmptyArray($key, $value)
     {
-        if ($this->isJsonCastable($key) && ! empty($value)) {
+        if ($this->isJsonCastable($key) && ! blank($value)) {
             return $this->setJsonCastValue($value);
         }
 
-        return empty($value) ? null : $value;
+        return blank($value) ? null : $value;
     }
 }

--- a/src/NullableFields.php
+++ b/src/NullableFields.php
@@ -166,7 +166,7 @@ trait NullableFields
     private function fetchValueForKey($key, $value)
     {
         if (in_array($key, $this->getDates())) {
-            return trim($value) === '' ? null : $value;
+            return trim((string) $value) === '' ? null : $value;
         }
 
         if (! $this->hasSetMutator($key)) {


### PR DESCRIPTION
I've been getting this warning/error on my laravel app running on PHP 8.1

PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated ... NullableFields.php on line 70

So I cast $value to string in trim() to avoid this warning/error in PHP 8.1

I'm not sure if we should add (string) cast inside all the other trim() too. See Line 169 of NullableFields.php

Tho my hunch tell me yes we should. So I did it for line 169 too.