### PR TITLE
Allow using a * to mark all fields as nullable

### DIFF
--- a/src/NullableFields.php
+++ b/src/NullableFields.php
@@ -121,6 +121,8 @@ trait NullableFields
     {
         if (is_array($this->nullable) && count($this->nullable) > 0) {
             return array_intersect_key($attributes, array_flip($this->nullable));
+        } else if ($this->nullable === '*') {
+            return $attributes;
         }
 
         // Assume no fields are nullable

--- a/tests/NullableFieldsIntegrationTest.php
+++ b/tests/NullableFieldsIntegrationTest.php
@@ -67,9 +67,48 @@ class NullableFieldsIntegrationTest extends TestCase
 
 
     /** @test */
+    public function it_sets_all_empty_fields_to_null_when_saving()
+    {
+        $user                   = new UserProfileAll();
+        $user->facebook_profile = ' ';
+        $user->twitter_profile  = 'michaeldyrynda';
+        $user->linkedin_profile = '';
+        $user->array_casted     = [];
+        $user->array_not_casted = [];
+        $user->save();
+
+        $this->assertNull($user->facebook_profile);
+        $this->assertSame('michaeldyrynda', $user->twitter_profile);
+        $this->assertNull($user->linkedin_profile);
+        $this->assertNull($user->array_casted);
+        $this->assertNull($user->array_not_casted);
+        $this->assertNull(null);
+    }
+
+
+    /** @test */
     public function it_sets_nullable_fields_to_null_when_mass_assignment_is_used()
     {
         $user = UserProfile::create([
+            'facebook_profile' => '',
+            'twitter_profile'  => 'michaeldyrynda',
+            'linkedin_profile' => ' ',
+            'array_casted'     => [],
+            'array_not_casted' => [],
+        ]);
+
+        $this->assertNull($user->facebook_profile);
+        $this->assertSame('michaeldyrynda', $user->twitter_profile);
+        $this->assertNull($user->linkedin_profile);
+        $this->assertNull($user->array_casted);
+        $this->assertNull($user->array_not_casted);
+    }
+
+
+    /** @test */
+    public function it_sets_all_empty_fields_to_null_when_mass_assignment_is_used()
+    {
+        $user = UserProfileAll::create([
             'facebook_profile' => '',
             'twitter_profile'  => 'michaeldyrynda',
             'linkedin_profile' => ' ',
@@ -206,6 +245,34 @@ class UserProfile extends Model
         'twitter_profile_mutated',
         'boolean',
     ];
+
+    protected $casts = ['array_casted' => 'array', 'boolean' => 'boolean'];
+
+    public function setTwitterProfileMutatedAttribute($twitter_profile_mutated)
+    {
+        $this->attributes['twitter_profile_mutated'] = sprintf('@%s', $twitter_profile_mutated);
+    }
+}
+
+class UserProfileAll extends Model
+{
+    use NullableFields;
+
+    public $table = 'user_profiles';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'facebook_profile',
+        'twitter_profile',
+        'linkedin_profile',
+        'array_casted',
+        'array_not_casted',
+        'twitter_profile_mutated',
+        'boolean',
+    ];
+
+    protected $nullable = '*';
 
     protected $casts = ['array_casted' => 'array', 'boolean' => 'boolean'];
 

--- a/tests/NullableFieldsIntegrationTest.php
+++ b/tests/NullableFieldsIntegrationTest.php
@@ -254,32 +254,11 @@ class UserProfile extends Model
     }
 }
 
-class UserProfileAll extends Model
+class UserProfileAll extends UserProfile
 {
-    use NullableFields;
-
     public $table = 'user_profiles';
 
-    public $timestamps = false;
-
-    protected $fillable = [
-        'facebook_profile',
-        'twitter_profile',
-        'linkedin_profile',
-        'array_casted',
-        'array_not_casted',
-        'twitter_profile_mutated',
-        'boolean',
-    ];
-
     protected $nullable = '*';
-
-    protected $casts = ['array_casted' => 'array', 'boolean' => 'boolean'];
-
-    public function setTwitterProfileMutatedAttribute($twitter_profile_mutated)
-    {
-        $this->attributes['twitter_profile_mutated'] = sprintf('@%s', $twitter_profile_mutated);
-    }
 }
 
 


### PR DESCRIPTION
For models where all empty fields should be assigned null, this makes the application's code more maintainable by not requiring every field be spelled out individually.